### PR TITLE
[TASK-004] Add L2 integration tests for farm scene and player wiring

### DIFF
--- a/godot-self-evolve-implementation-system/zombie-farm-demo/scenes/farm_scene.tscn
+++ b/godot-self-evolve-implementation-system/zombie-farm-demo/scenes/farm_scene.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=3 uid="uid://b1farmscene"]
+
+[ext_resource type="Script" path="res://scripts/player.gd" id="1_player"]
+
+[node name="FarmScene" type="Node2D"]
+
+[node name="Player" type="CharacterBody2D" parent="."]
+script = ExtResource("1_player")

--- a/godot-self-evolve-implementation-system/zombie-farm-demo/scripts/player.gd
+++ b/godot-self-evolve-implementation-system/zombie-farm-demo/scripts/player.gd
@@ -1,0 +1,18 @@
+extends CharacterBody2D
+## Player character script — handles WASD movement.
+
+const SPEED: float = 200.0
+
+
+func _physics_process(_delta: float) -> void:
+	var direction: Vector2 = Vector2.ZERO
+	if Input.is_action_pressed("move_up"):
+		direction.y -= 1.0
+	if Input.is_action_pressed("move_down"):
+		direction.y += 1.0
+	if Input.is_action_pressed("move_left"):
+		direction.x -= 1.0
+	if Input.is_action_pressed("move_right"):
+		direction.x += 1.0
+	velocity = direction.normalized() * SPEED
+	move_and_slide()

--- a/godot-self-evolve-implementation-system/zombie-farm-demo/tests/integration/test_farm_scene.gd
+++ b/godot-self-evolve-implementation-system/zombie-farm-demo/tests/integration/test_farm_scene.gd
@@ -1,0 +1,51 @@
+extends GutTest
+## L2 Integration tests for farm_scene.tscn and player wiring.
+
+var _scene_instance: Node
+
+
+func before_each() -> void:
+	_scene_instance = null
+
+
+func after_each() -> void:
+	if is_instance_valid(_scene_instance):
+		_scene_instance.queue_free()
+	_scene_instance = null
+
+
+func test_farm_scene_loads() -> void:
+	var packed: PackedScene = load("res://scenes/farm_scene.tscn")
+	assert_not_null(packed, "farm_scene.tscn should load as a non-null PackedScene")
+	assert_true(packed is PackedScene, "loaded resource should be a PackedScene")
+	_scene_instance = packed.instantiate()
+	assert_not_null(_scene_instance, "instantiated farm scene should not be null")
+	assert_true(_scene_instance is Node, "instantiated scene should be a Node")
+	add_child_autofree(_scene_instance)
+
+
+func test_player_node_present() -> void:
+	var packed: PackedScene = load("res://scenes/farm_scene.tscn")
+	assert_not_null(packed, "farm_scene.tscn must load")
+	_scene_instance = packed.instantiate()
+	add_child_autofree(_scene_instance)
+	var players: Array = _scene_instance.find_children("*", "CharacterBody2D", true, false)
+	var found_player: bool = false
+	for node in players:
+		if node.get_script() != null:
+			var script_path: String = node.get_script().resource_path
+			if "player" in script_path.to_lower():
+				found_player = true
+				break
+	if not found_player:
+		var direct: Node = _scene_instance.find_child("Player", true, false)
+		if direct != null:
+			found_player = true
+	assert_true(found_player, "farm scene should contain a Player node in its subtree")
+
+
+func test_wasd_input_actions_registered() -> void:
+	assert_true(InputMap.has_action("move_up"), "InputMap should have action 'move_up'")
+	assert_true(InputMap.has_action("move_down"), "InputMap should have action 'move_down'")
+	assert_true(InputMap.has_action("move_left"), "InputMap should have action 'move_left'")
+	assert_true(InputMap.has_action("move_right"), "InputMap should have action 'move_right'")


### PR DESCRIPTION
## Summary
- Add `scenes/farm_scene.tscn` with a `CharacterBody2D` Player node for test dependency
- Add `scripts/player.gd` with WASD movement using project input actions
- Add `tests/integration/test_farm_scene.gd` with 3 GutTest integration tests

## Tests Added
- `test_farm_scene_loads` — verifies `farm_scene.tscn` loads as a non-null PackedScene and instantiates a valid Node
- `test_player_node_present` — verifies farm scene subtree contains a CharacterBody2D with player.gd script (or a node named "Player")
- `test_wasd_input_actions_registered` — verifies InputMap has move_up, move_down, move_left, move_right actions

## Test Results
All 3 tests pass headless: **3/3 passing, 10 asserts, 0.418s**

## Test plan
- [x] Run `godot --headless -s addons/gut/gut_cmdln.gd -gdir=res://tests/integration/` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)