### PR TITLE
[Cycle 10] Create seed_inventory.gd SeedInventory autoload with add_seed, remove_seed, get_seeds

### DIFF
--- a/godot-self-evolve-implementation-system/zombie-farm-demo/scripts/seed_inventory.gd
+++ b/godot-self-evolve-implementation-system/zombie-farm-demo/scripts/seed_inventory.gd
@@ -1,4 +1,3 @@
-class_name SeedInventory
 extends Node
 ## SeedInventory autoload — tracks seed quantities across the game session.
 


### PR DESCRIPTION
## Task
- Task ID: TASK-018
- Cycle: 10
- Type: feature

## PRD References
- None (no PRD files exist for this project)

## Changes Summary
Created `zombie-farm-demo/scripts/seed_inventory.gd` as a Node-extending autoload named SeedInventory. The script stores seed quantities in a private `_inventory: Dictionary`, declares the `inventory_changed` signal, and implements three public methods: `add_seed`, `remove_seed`, and `get_seeds`. Registered `SeedInventory` in `project.godot` as an autoload. Added GUT unit tests in `zombie-farm-demo/tests/unit/test_seed_inventory.gd` covering all public methods, edge cases, and signal emissions.

## Acceptance Criteria Verification
[
  {
    "criterion": "File exists at zombie-farm-demo/scripts/seed_inventory.gd with class_name SeedInventory and extends Node",
    "verified": false,
    "evidence": "The file exists at scripts/seed_inventory.gd with `extends Node`. However, Godot 4 raises a parse error — 'Class SeedInventory hides an autoload singleton' — when class_name matches the autoload name. class_name was intentionally omitted to keep the autoload functional. extends Node is present (line 1)."
  },
  {
    "criterion": "Signal declared as signal inventory_changed(seed_id: String, new_quantity: int) at top of file",
    "verified": true,
    "evidence": "scripts/seed_inventory.gd line 3: `signal inventory_changed(seed_id: String, new_quantity: int)`"
  },
  {
    "criterion": "Private field var _inventory: Dictionary = {} present",
    "verified": true,
    "evidence": "scripts/seed_inventory.gd line 5: `var _inventory: Dictionary = {}`"
  },
  {
    "criterion": "add_seed(seed_id: String, quantity: int) -> void adds quantity to _inventory[seed_id] (creating the key if absent) and emits inventory_changed",
    "verified": true,
    "evidence": "scripts/seed_inventory.gd lines 11-20: adds to existing key or creates new one via `_inventory.get(seed_id, 0)`, then emits inventory_changed. Tests: test_add_seed_creates_key_when_absent, test_add_seed_accumulates_quantity, test_add_seed_emits_signal."
  },
  {
    "criterion": "remove_seed(seed_id: String, quantity: int) -> bool returns false and does NOT modify _inventory when current quantity is less than requested; returns true and decrements when sufficient, emits inventory_changed",
    "verified": true,
    "evidence": "scripts/seed_inventory.gd lines 26-38: returns false when current < quantity without modifying inventory; decrements and emits when sufficient. Tests: test_remove_seed_returns_false_when_insufficient, test_remove_seed_does_not_modify_when_insufficient, test_remove_seed_returns_true_when_sufficient, test_remove_seed_emits_signal."
  },
  {
    "criterion": "get_seeds() -> Dictionary returns a .duplicate() of _inventory, not the original reference",
    "verified": true,
    "evidence": "scripts/seed_inventory.gd line 43: `return _inventory.duplicate()`. Test: test_get_seeds_returns_duplicate_not_reference."
  },
  {
    "criterion": "All variables, parameters, and return types are statically typed — no untyped declarations",
    "verified": true,
    "evidence": "All variables use explicit types: `_inventory: Dictionary`, `current: int`. All function signatures have typed parameters and return types: `-> void`, `-> bool`, `-> Dictionary`. Signal parameters are typed."
  }
]

## Test Results
- L1 GUT: 45/46 passed (1 pre-existing failure in test_smoke.gd::test_string_operations, unrelated to this task)
- SeedInventory tests: all pass

## Scene/Node Changes
None

## Signal Changes
- `inventory_changed(seed_id: String, new_quantity: int)` — emitted by SeedInventory autoload after any quantity change

## Data Changes
None

## Decisions Made
- Omitted `class_name SeedInventory` because Godot 4 raises a fatal parse error ("Class SeedInventory hides an autoload singleton") when a script's class_name matches its autoload registration name. The autoload is accessible globally via the autoload name without class_name.
- Used `_inventory.get(seed_id, 0)` instead of `has()` check to atomically default-and-read, simplifying add_seed.
- `get_seeds()` returns `.duplicate()` to prevent callers from mutating internal state.

## Constraints Discovered
- Godot 4.6.1 does not allow `class_name` to match an autoload singleton name — this causes a parse error at startup. Acceptance criterion #1 requiring `class_name SeedInventory` is unachievable while also registering SeedInventory as an autoload.

## Asset Changes
None