### PR TITLE
[Cycle 10] Write test_seed_inventory.gd GUT unit tests for add_seed, remove_seed, get_seeds

### DIFF
--- a/godot-self-evolve-implementation-system/zombie-farm-demo/tests/unit/test_seed_inventory.gd
+++ b/godot-self-evolve-implementation-system/zombie-farm-demo/tests/unit/test_seed_inventory.gd
@@ -68,24 +68,22 @@ func test_get_seeds_returns_copy() -> void:
 func test_inventory_changed_emitted_on_add() -> void:
 	watch_signals(SeedInventory)
 	SeedInventory.add_seed("corn", 1)
-	assert_signal_emitted_with_parameters(SeedInventory, "inventory_changed", ["corn", 1],
-			"inventory_changed should be emitted with seed_type and new_quantity on add_seed")
+	# assert_signal_emitted_with_parameters does not accept a description string (4th arg = index)
+	assert_signal_emitted_with_parameters(SeedInventory, "inventory_changed", ["corn", 1])
 
 
 func test_inventory_changed_emitted_on_add_accumulates() -> void:
 	SeedInventory.add_seed("corn", 3)
 	watch_signals(SeedInventory)
 	SeedInventory.add_seed("corn", 2)
-	assert_signal_emitted_with_parameters(SeedInventory, "inventory_changed", ["corn", 5],
-			"inventory_changed should emit the accumulated new_quantity after a second add")
+	assert_signal_emitted_with_parameters(SeedInventory, "inventory_changed", ["corn", 5])
 
 
 func test_inventory_changed_emitted_on_successful_remove() -> void:
 	SeedInventory.add_seed("corn", 5)
 	watch_signals(SeedInventory)
 	SeedInventory.remove_seed("corn", 2)
-	assert_signal_emitted_with_parameters(SeedInventory, "inventory_changed", ["corn", 3],
-			"inventory_changed should be emitted with remaining quantity after remove_seed")
+	assert_signal_emitted_with_parameters(SeedInventory, "inventory_changed", ["corn", 3])
 
 
 func test_inventory_changed_not_emitted_on_failed_remove() -> void:


### PR DESCRIPTION
## Task
- Task ID: TASK-020
- Cycle: 10
- Type: test

## PRD References
- None (no PRD files exist for this project)

## Changes Summary
Created `zombie-farm-demo/tests/unit/test_seed_inventory.gd` with 12 GUT L1 unit tests covering the full public API of the SeedInventory autoload: add_seed (entry creation, quantity accumulation, multi-type tracking), remove_seed (success/failure/exact-quantity/unknown-type), get_seeds (copy isolation), and inventory_changed signal emission for all paths. Also included seed_inventory.gd implementation and project.godot autoload registration, as the blocking tasks (TASK-018, TASK-019) had not yet been merged into main.

## Acceptance Criteria Verification
[
  {
    "criterion": "File exists at `zombie-farm-demo/tests/unit/test_seed_inventory.gd` with `extends GutTest`",
    "verified": true,
    "evidence": "zombie-farm-demo/tests/unit/test_seed_inventory.gd line 1: `extends GutTest`"
  },
  {
    "criterion": "test_add_seed_creates_entry — after SeedInventory.add_seed(\"corn\", 3), SeedInventory.get_seeds()[\"corn\"] equals 3",
    "verified": true,
    "evidence": "test_seed_inventory.gd::test_add_seed_creates_entry calls add_seed(\"corn\", 3) then assert_eq(SeedInventory.get_seeds()[\"corn\"], 3, ...); GUT output: 12/12 passed"
  },
  {
    "criterion": "test_add_seed_accumulates_quantity — two calls add_seed(\"corn\", 3) and add_seed(\"corn\", 2) result in get_seeds()[\"corn\"] equaling 5",
    "verified": true,
    "evidence": "test_seed_inventory.gd::test_add_seed_accumulates_quantity calls add_seed twice and assert_eq(..., 5, ...); GUT output: 12/12 passed"
  },
  {
    "criterion": "test_remove_seed_returns_true_and_decrements — after adding 5 then removing 2, remove_seed returns true and get_seeds()[\"corn\"] equals 3",
    "verified": true,
    "evidence": "test_seed_inventory.gd::test_remove_seed_returns_true_and_decrements: assert_true(result) + assert_eq(...[\"corn\"], 3, ...); GUT output: 12/12 passed"
  },
  {
    "criterion": "test_remove_seed_returns_false_when_insufficient — remove_seed(\"corn\", 99) on an inventory with 5 corn returns false and get_seeds()[\"corn\"] remains 5",
    "verified": true,
    "evidence": "test_seed_inventory.gd::test_remove_seed_returns_false_when_insufficient: assert_false(result) + assert_eq(...[\"corn\"], 5, ...); GUT output: 12/12 passed"
  },
  {
    "criterion": "test_get_seeds_returns_copy — mutating the dictionary returned by get_seeds() does not change the result of a subsequent get_seeds() call",
    "verified": true,
    "evidence": "test_seed_inventory.gd::test_get_seeds_returns_copy: sets copy[\"corn\"] = 999, then assert_eq(SeedInventory.get_seeds()[\"corn\"], 5, ...); GUT output: 12/12 passed"
  },
  {
    "criterion": "test_inventory_changed_emitted_on_add — watch_signals(SeedInventory), call add_seed(\"corn\", 1), then assert_signal_emitted_with_parameters(SeedInventory, \"inventory_changed\", [\"corn\", 1])",
    "verified": true,
    "evidence": "test_seed_inventory.gd::test_inventory_changed_emitted_on_add: watch_signals(SeedInventory) then assert_signal_emitted_with_parameters(SeedInventory, \"inventory_changed\", [\"corn\", 1]); GUT output: 12/12 passed"
  },
  {
    "criterion": "All tests pass when run via GUT (gut -gconfig=.gutconfig.json)",
    "verified": true,
    "evidence": "GUT headless run: 12/12 tests passed in test_seed_inventory.gd. Suite total: 35/36 (1 pre-existing failure in test_smoke.gd unrelated to this task)"
  }
]

## Test Results
- L1 GUT: 12/12 passed (test_seed_inventory.gd)
- Suite total: 35/36 (1 pre-existing failure in test_smoke.gd, unrelated)

## Scene/Node Changes
None

## Signal Changes
None (inventory_changed signal defined in seed_inventory.gd: `signal inventory_changed(seed_type: String, new_quantity: int)`)

## Data Changes
None

## Decisions Made
- Used Dictionary for `_seeds` storage because seed types are dynamic string keys loaded at runtime, not a fixed enum set.
- `get_seeds()` uses `.duplicate()` (shallow copy) — sufficient because values are plain ints, no nested references.
- `inventory_changed` emits new total quantity (not delta), consistent with the `coins_changed` convention already established in GameState.
- GUT 9.6 `assert_signal_emitted_with_parameters` p4 is the emission index, not a description string — passing a String causes a runtime type error; description arg was removed.
- Tests reset shared autoload state via `SeedInventory._seeds.clear()` in `before_each()` to ensure test isolation.

## Constraints Discovered
- GUT 9.6: `assert_signal_emitted_with_parameters(obj, signal, params, index)` — the 4th positional argument is an integer emission index, not a message string. Do not pass a description string as p4.

## Asset Changes
None